### PR TITLE
Add password support for redis

### DIFF
--- a/requests_respectful/globals.py
+++ b/requests_respectful/globals.py
@@ -16,6 +16,7 @@ default_config = {
     "redis": {
         "host": "localhost",
         "port": 6379,
+        "password": None,
         "database": 0
     },
     "safety_threshold": 10,
@@ -45,7 +46,7 @@ try:
     if "redis" not in config:
         raise RequestsRespectfulConfigError("'redis' key is missing from 'requests-respectful.config.yml'")
 
-    expected_redis_keys = ["host", "port", "database"]
+    expected_redis_keys = ["host", "port", "password", "database"]
     missing_redis_keys = list()
 
     for expected_redis_key in expected_redis_keys:
@@ -67,5 +68,6 @@ except FileNotFoundError:
 redis = StrictRedis(
     host=config["redis"]["host"],
     port=config["redis"]["port"],
+    password=config["redis"]["password"],
     db=config["redis"]["database"]
 )

--- a/requests_respectful/respectful_requester.py
+++ b/requests_respectful/respectful_requester.py
@@ -111,7 +111,7 @@ class RespectfulRequester:
             if type(kwargs["redis"]) != dict:
                 raise RequestsRespectfulConfigError("'redis' key must be a dict")
 
-            expected_redis_keys = ["host", "port", "database"]
+            expected_redis_keys = ["host", "port", "password", "database"]
             missing_redis_keys = list()
 
             for expected_redis_key in expected_redis_keys:
@@ -130,6 +130,7 @@ class RespectfulRequester:
             redis = StrictRedis(
                 host=config["redis"]["host"],
                 port=config["redis"]["port"],
+                password=config["redis"]["password"],
                 db=config["redis"]["database"]
             )
 


### PR DESCRIPTION
This commit adds password support to redis by adding some expected arguments and adding arguments to `StrictRedis` which [supports the password option](http://redis-py.readthedocs.io/en/latest/#redis.StrictRedis).

Some rationale behind this:

- This is almost always going to be required when deploying to an environment such as Heroku or anywhere that uses containers; there are most often passwords since it's for the security of inter-container communication. 
- Even if not using containers, and you have a Redis server, there's most likely a password set on it.
- Many other production environments use a password even if their Redis installation is on the same VM.

I'd be happy to make any additional adjustments here. I've tested this in an application and it connects and runs successfully with no password on localhost, and with a password set on my production environment.